### PR TITLE
Fix uninitialized remote_sell flag

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,7 +12,8 @@ portMUX_TYPE muxCounter = portMUX_INITIALIZER_UNLOCKED;
 
 int8_t remote_type = NONE;
 uint16_t pulse_counter = 0;
-bool reset = false, selecting_opt = false, loading = false, redeem_beer = false, remote_sell;
+bool reset = false, selecting_opt = false, loading = false, redeem_beer = false,
+     remote_sell = false;
 
 //-------------------------------------->Set UP
 void setup() {


### PR DESCRIPTION
## Summary
- avoid undefined behavior by initializing `remote_sell` to `false`

## Testing
- `pio --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f4539d0b083209663ec2be71c22ab